### PR TITLE
Allow disabling the hidden preferences window.

### DIFF
--- a/source/browser.ts
+++ b/source/browser.ts
@@ -220,7 +220,10 @@ ipc.answerMain('archive-conversation', async () => {
 
 async function openHiddenPreferences(): Promise<boolean> {
 	if (!isPreferencesOpen()) {
-		document.documentElement.classList.add('hide-preferences-window');
+		const disableSettingsHiding = await ipc.callMain<undefined, boolean>('get-config-disableSettingsHiding');
+		if (!disableSettingsHiding) {
+			document.documentElement.classList.add('hide-preferences-window');
+		}
 
 		await openPreferences();
 
@@ -675,7 +678,10 @@ async function closePreferences(): Promise<void> {
 	// Get the parent of preferences, that's not getting deleted
 	const preferencesParent = preferencesOverlay.closest('div:not([class])')!;
 
-	preferencesOverlayObserver.observe(preferencesParent, {childList: true});
+	const disableSettingsHiding = await ipc.callMain<undefined, boolean>('get-config-disableSettingsHiding');
+	if (!disableSettingsHiding) {
+		preferencesOverlayObserver.observe(preferencesParent, {childList: true});
+	}
 
 	const closeButton = preferencesOverlay.querySelector(selectors.closePreferencesButton)!;
 	(closeButton as HTMLElement)?.click();

--- a/source/config.ts
+++ b/source/config.ts
@@ -44,6 +44,7 @@ export type StoreType = {
 	autoplayVideos: boolean;
 	isSpellCheckerEnabled: boolean;
 	spellCheckerLanguages: string[];
+	disableSettingsHiding: boolean;
 };
 
 const schema: Store.Schema<StoreType> = {
@@ -217,6 +218,10 @@ const schema: Store.Schema<StoreType> = {
 			type: 'string',
 		},
 		default: [],
+	},
+	disableSettingsHiding: {
+		type: 'boolean',
+		default: false,
 	},
 };
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -680,3 +680,4 @@ ipc.answerRenderer<undefined, StoreType['emojiStyle']>('get-config-emojiStyle', 
 ipc.answerRenderer<StoreType['emojiStyle'], void>('set-config-emojiStyle', async emojiStyle => {
 	config.set('emojiStyle', emojiStyle);
 });
+ipc.answerRenderer<undefined, StoreType['disableSettingsHiding']>('get-config-disableSettingsHiding', async () => config.get('disableSettingsHiding'));

--- a/source/menu.ts
+++ b/source/menu.ts
@@ -233,6 +233,14 @@ Press Command/Ctrl+R in Caprine to see your changes.
 				shell.openPath(filePath);
 			},
 		},
+		{
+			label: 'Disable Settings Hiding',
+			type: 'checkbox',
+			checked: config.get('disableSettingsHiding'),
+			click() {
+				config.set('disableSettingsHiding', !config.get('disableSettingsHiding'));
+			},
+		},
 	];
 
 	const preferencesSubmenu: MenuItemConstructorOptions[] = [


### PR DESCRIPTION
This gives an option under advanced settings allowing the user to disable the hidden preferences window when applying settings (i.e., adding the hide-preferences-window class when caprine opens settings). This will be disabled by default (current behavior). If enabled, you'll very briefly see the settings window flash when caprine applies a setting inside Messenger.